### PR TITLE
feat(ci/cd): reuse Build Workflow in Release Workflow

### DIFF
--- a/.github/workflows/01-build.yml
+++ b/.github/workflows/01-build.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - "main"
   pull_request:
+  workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
+    outputs:
+      run-id:
+        description:
+        value: ${{ jobs.build.outputs.run-id }}
 
 jobs:
   build:
@@ -75,6 +83,7 @@ jobs:
           source-path: ./target/site/jacoco-aggregate/
 
   quality-check:
+    if: ${{ github.event_name != 'workflow_call' }}
     needs: coverage-report
     uses: ./.github/workflows/02-sonarcloud.yml
     permissions:

--- a/.github/workflows/04-release.yml
+++ b/.github/workflows/04-release.yml
@@ -53,6 +53,8 @@ jobs:
     name: Build
     needs: preflight
     uses: ./.github/workflows/01-build.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   release:
     name: Release
@@ -69,6 +71,9 @@ jobs:
             exit 1
           fi
       - uses: ./.github/actions/download_intermediate_artifacts
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy release artifacts (GitHub Packages)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use GitHub Actions's reusable Workflow feature to leave building of the artifact to the Build Workflow. Download the compiled classes from this workflow to reduce the build time of the Maven's Deploy phase.

## Type
- [ ] feat
- [x] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] test
